### PR TITLE
Fix for value_mapping_field access to id = False

### DIFF
--- a/addons/etl/action.py
+++ b/addons/etl/action.py
@@ -217,7 +217,7 @@ class action(models.Model):
                 ('manager_id', '=', self.manager_id.id)])
             if value_mappings:
                 mapping_type = 'value_mapping'
-                value_mapping_field.id = value_mappings[0]
+                value_mapping_field = value_mappings[0]
 
             # If field name = 'state' then we upload it on a repeating action so we are sure we can upload all the related data
             if field.name == 'state':


### PR DESCRIPTION
value_mapping_field is set to False, when a mapping is found, an attempt to access value_mapping_field.is is made, but it fails, since the object is False
