### PR TITLE
Add Target Type on Manager, Fix Many2one, Many2Many in builded_id targer type

### DIFF
--- a/etl/manager.py
+++ b/etl/manager.py
@@ -147,6 +147,15 @@ class manager(models.Model):
         # TODO improove this and load all translations for tranlatable fields
         help='Language used on target database translatable fields'
         )
+    target_id_type = fields.Selection(
+        [(u'source_id', 'Source ID'), (u'builded_id', 'Builded ID')],
+        string='Target ID Type',
+        required=True,
+        default='builded_id',
+        help="Selection on how the Records target ID's will be build:\n\t"
+             "    - Source ID - will keep the source ID (external_id)\n\t"
+             "    - Builded ID - every external ID will be build as concatenation of Manager Name + _ + Source Model"   
+        )
 
     _constraints = [
     ]

--- a/etl/view/manager_view.xml
+++ b/etl/view/manager_view.xml
@@ -55,6 +55,9 @@
                         <group>
                             <field name="name"/>
                         </group>
+                        <group>
+                            <field name="target_id_type"/>
+                        </group>
                         <group col="6">
                             <field name="source_hostname"
                                 />


### PR DESCRIPTION
Add easier configuration for source ID, builded ID on Manager, it's usefull when try to move one database to a multicompany one, fix mappings of many2one and many2many in a builded Id target type.
